### PR TITLE
feat: bump themekit version to 1.1.5

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -2,7 +2,7 @@ const path = require('path');
 
 module.exports = {
   baseURL: 'https://shopify-themekit.s3.amazonaws.com',
-  version: '1.1.4',
+  version: '1.1.5',
   destination: path.join(__dirname, '..', 'bin'),
   binName: process.platform === 'win32' ? 'theme.exe' : 'theme'
 };


### PR DESCRIPTION
### What are you trying to accomplish with this PR?

Bump themekit version to 1.1.5 which includes optimization for watcher to reduce CPU usage.

### Checklist
For contributors:
- [x] I have updated the documentation in the [README file](https://github.com/Shopify/node-themekit/blob/master/README.md) to reflect these changes, if applicable.

